### PR TITLE
Changed frame names of in and outgoing transforms

### DIFF
--- a/odometry.orogen
+++ b/odometry.orogen
@@ -87,7 +87,7 @@ task_context 'LatOdom' do
     ##########################
 
     transformer() do
-        transformation("body", "imu_world")
+        transformation("imu_body", "imu_world")
 
         align_port("actuator_samples", 0.001)
         max_latency(0.1)
@@ -130,12 +130,13 @@ task_context 'Skid' do
         needs_reliable_connection.
         doc 'timestamped motor state samples providing odometry information.'
 
+
     ##########################
     # aggregator parameters
     ##########################
 
     transformer() do
-        transformation("body", "imu_world")
+        transformation("imu_body", "imu_world")
 
         align_port("actuator_samples", 0.001)
         max_latency(0.1)

--- a/odometry.orogen
+++ b/odometry.orogen
@@ -86,7 +86,7 @@ task_context 'LatOdom' do
     # aggregator parameters
     ##########################
 
-    transformer() do
+    transformer do
         transformation("imu_body", "imu_world")
 
         align_port("actuator_samples", 0.001)
@@ -135,7 +135,7 @@ task_context 'Skid' do
     # aggregator parameters
     ##########################
 
-    transformer() do
+    transformer do
         transformation("imu_body", "imu_world")
 
         align_port("actuator_samples", 0.001)

--- a/tasks/LatOdom.cpp
+++ b/tasks/LatOdom.cpp
@@ -42,7 +42,7 @@ void LatOdom::printInvalidSample()
     std::cerr << "    " << s2.str() << std::endl;
 }
 
-void LatOdom::body2imu_enuTransformerCallback(const base::Time& ts)
+void LatOdom::imu_body2imu_worldTransformerCallback(const base::Time& ts)
 {
     //we need to receive an actuator reading first
     if(!gotActuatorReading)
@@ -51,7 +51,7 @@ void LatOdom::body2imu_enuTransformerCallback(const base::Time& ts)
     // use the transformer to get the body2world transformation 
     // this should include the imu reading
     base::Transform3d body2IMUWorld;
-    if( !_body2imu_world.get( ts, body2IMUWorld ) )
+    if( !_imu_body2imu_world.get( ts, body2IMUWorld ) )
         return;
 
     // calculates the rotation from body to world base on the orientation measurment 
@@ -100,8 +100,6 @@ bool LatOdom::configureHook()
             _trackWidth.get(),
             _wheelBase.get(),
             leftWheelNames, rightWheelNames, leftSteeringNames, rightSteeringNames));
-
-    _body2imu_world.registerUpdateCallback(boost::bind(&LatOdom::body2imu_enuTransformerCallback, this, _1));
 
     return true;
 }

--- a/tasks/LatOdom.cpp
+++ b/tasks/LatOdom.cpp
@@ -23,30 +23,6 @@ void LatOdom::actuator_samplesTransformerCallback(const base::Time &ts, const ::
 {
     currentActuatorSample = actuator_samples;
     actuatorUpdated = true;
-    gotActuatorReading = true;
-}
-
-void LatOdom::printInvalidSample()
-{
-    std::cerr << "Invalid actuator sample:" << std::endl;
-    std::cerr << "  Expected the following joint names:" << std::endl;
-    std::stringstream s;
-    std::copy(leftWheelNames.begin(),leftWheelNames.end(), std::ostream_iterator<std::string>(s,", "));
-    std::copy(rightWheelNames.begin(),rightWheelNames.end(), std::ostream_iterator<std::string>(s,", "));
-    std::copy(leftSteeringNames.begin(),leftSteeringNames.end(), std::ostream_iterator<std::string>(s,", "));
-    std::copy(rightSteeringNames.begin(),rightSteeringNames.end(), std::ostream_iterator<std::string>(s,", "));
-    std::cerr << "    " << s.str() << std::endl;
-    std::cerr << "  But got the following joint names:" << std::endl;
-    std::stringstream s2;
-    std::copy(currentActuatorSample.names.begin(),currentActuatorSample.names.end(), std::ostream_iterator<std::string>(s2,", "));
-    std::cerr << "    " << s2.str() << std::endl;
-}
-
-void LatOdom::imu_body2imu_worldTransformerCallback(const base::Time& ts)
-{
-    //we need to receive an actuator reading first
-    if(!gotActuatorReading)
-        return;
     
     // use the transformer to get the body2world transformation 
     // this should include the imu reading
@@ -74,7 +50,22 @@ void LatOdom::imu_body2imu_worldTransformerCallback(const base::Time& ts)
 
     // push the transformations
     pushState( ts, body2PrevBody, R_body2World );
+}
 
+void LatOdom::printInvalidSample()
+{
+    std::cerr << "Invalid actuator sample:" << std::endl;
+    std::cerr << "  Expected the following joint names:" << std::endl;
+    std::stringstream s;
+    std::copy(leftWheelNames.begin(),leftWheelNames.end(), std::ostream_iterator<std::string>(s,", "));
+    std::copy(rightWheelNames.begin(),rightWheelNames.end(), std::ostream_iterator<std::string>(s,", "));
+    std::copy(leftSteeringNames.begin(),leftSteeringNames.end(), std::ostream_iterator<std::string>(s,", "));
+    std::copy(rightSteeringNames.begin(),rightSteeringNames.end(), std::ostream_iterator<std::string>(s,", "));
+    std::cerr << "    " << s.str() << std::endl;
+    std::cerr << "  But got the following joint names:" << std::endl;
+    std::stringstream s2;
+    std::copy(currentActuatorSample.names.begin(),currentActuatorSample.names.end(), std::ostream_iterator<std::string>(s2,", "));
+    std::cerr << "    " << s2.str() << std::endl;
 }
 
 /// The following lines are template definitions for the various state machine
@@ -110,7 +101,6 @@ bool LatOdom::startHook()
     
     prev_ts = base::Time();
     actuatorUpdated = false;
-    gotActuatorReading = false;
     
     return true;
 }

--- a/tasks/LatOdom.hpp
+++ b/tasks/LatOdom.hpp
@@ -35,7 +35,7 @@ namespace odometry{
 
         base::samples::Joints currentActuatorSample;
         bool actuatorUpdated;
-        bool gotActuatorReading = false, gotSteeringActuatorReading = false;
+        bool gotSteeringActuatorReading = false;
 
         
         std::vector<std::string> leftWheelNames;
@@ -43,7 +43,6 @@ namespace odometry{
         std::vector<std::string> leftSteeringNames;
         std::vector<std::string> rightSteeringNames;
         
-        void imu_body2imu_worldTransformerCallback(const base::Time &ts);
         void printInvalidSample();
         double wheelRadius;
         

--- a/tasks/LatOdom.hpp
+++ b/tasks/LatOdom.hpp
@@ -43,7 +43,7 @@ namespace odometry{
         std::vector<std::string> leftSteeringNames;
         std::vector<std::string> rightSteeringNames;
         
-        void body2imu_enuTransformerCallback(const base::Time &ts);
+        void imu_body2imu_worldTransformerCallback(const base::Time &ts);
         void printInvalidSample();
         double wheelRadius;
         

--- a/tasks/Skid.cpp
+++ b/tasks/Skid.cpp
@@ -91,7 +91,7 @@ double Skid::getMovingSpeed()
 }
 
 
-void Skid::body2imu_enuTransformerCallback(const base::Time& ts)
+void Skid::imu_body2imu_worldTransformerCallback(const base::Time& ts)
 {
     //we need to receive an actuator reading first
     if(!gotActuatorReading)
@@ -100,7 +100,7 @@ void Skid::body2imu_enuTransformerCallback(const base::Time& ts)
     // use the transformer to get the body2world transformation 
     // this should include the imu reading
     base::Transform3d body2IMUWorld;
-    if( !_body2imu_world.get( ts, body2IMUWorld ) )
+    if( !_imu_body2imu_world.get( ts, body2IMUWorld ) )
 	return;
 
     // calculates the rotation from body to world base on the orientation measurment 
@@ -183,8 +183,6 @@ bool Skid::configureHook()
 	    _trackWidth.get(),
 	    _wheelBase.get(),
             leftWheelNames, rightWheelNames));
-
-    _body2imu_world.registerUpdateCallback(boost::bind(&Skid::body2imu_enuTransformerCallback, this, _1));
 
     return true;
 }

--- a/tasks/Skid.cpp
+++ b/tasks/Skid.cpp
@@ -19,13 +19,6 @@ Skid::~Skid()
 {
 }
 
-void Skid::actuator_samplesTransformerCallback(const base::Time &ts, const ::base::samples::Joints &actuator_samples)
-{
-    currentActuatorSample = actuator_samples;
-    actuatorUpdated = true;
-    gotActuatorReading = true;
-}
-
 void Skid::printInvalidSample()
 {
     std::cerr << "Invalid actuator sample:" << std::endl;
@@ -91,11 +84,10 @@ double Skid::getMovingSpeed()
 }
 
 
-void Skid::imu_body2imu_worldTransformerCallback(const base::Time& ts)
+void Skid::actuator_samplesTransformerCallback(const base::Time &ts, const base::samples::Joints &actuator_samples)
 {
-    //we need to receive an actuator reading first
-    if(!gotActuatorReading)
-        return;
+    currentActuatorSample = actuator_samples;
+    actuatorUpdated = true;
     
     // use the transformer to get the body2world transformation 
     // this should include the imu reading
@@ -194,7 +186,6 @@ bool Skid::startHook()
     prev_ts = base::Time();
     actuatorUpdated = false;
     lastMovingSpeed = 0.0;
-    gotActuatorReading = false;
     
     return true;
 }

--- a/tasks/Skid.hpp
+++ b/tasks/Skid.hpp
@@ -43,7 +43,7 @@ namespace odometry {
         std::vector<std::string> rightWheelNames;
 
         virtual void actuator_samplesTransformerCallback(const base::Time &ts, const ::base::samples::Joints &actuator_samples_sample);
-        void body2imu_enuTransformerCallback(const base::Time &ts);
+        void imu_body2imu_worldTransformerCallback(const base::Time &ts);
         void printInvalidSample();
         
         /** 

--- a/tasks/Skid.hpp
+++ b/tasks/Skid.hpp
@@ -36,14 +36,12 @@ namespace odometry {
         base::samples::Joints currentActuatorSample;
         bool actuatorUpdated;
         double lastMovingSpeed;
-        bool gotActuatorReading;
 
         
         std::vector<std::string> leftWheelNames;
         std::vector<std::string> rightWheelNames;
 
         virtual void actuator_samplesTransformerCallback(const base::Time &ts, const ::base::samples::Joints &actuator_samples_sample);
-        void imu_body2imu_worldTransformerCallback(const base::Time &ts);
         void printInvalidSample();
         
         /** 


### PR DESCRIPTION
Will now subscribe to "imu_body" => "imu_world", but publish "body" => "odometry" to avoid loops in the transformer graph.

Also had to fix stream aligner usage.

Only tested "Skid" task in simulation so far.
